### PR TITLE
Connection trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # loadbalancer
+
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Documentation](https://godoc.org/github.com/jmbarzee/loadbalancer?status.svg)](https://godoc.org/github.com/jmbarzee/loadbalancer)
+[![Code Quality](https://goreportcard.com/badge/github.com/jmbarzee/loadbalancer)](https://goreportcard.com/report/github.com/jmbarzee/loadbalancer)
+
 TCP LoadBalancer - Supporting authentication, authorization, and rate limiting

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/jmbarzee/loadbalancer
+
+go 1.20
+
+require (
+	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.6.0
+)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/jmbarzee/loadbalancer
 
 go 1.20
 
-require (
-	github.com/google/go-cmp v0.6.0
-	github.com/google/uuid v1.6.0
-)
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/tracker/downstream.go
+++ b/internal/tracker/downstream.go
@@ -11,7 +11,7 @@ type DownstreamConns struct {
 	// mu protects the resources of DownstreamConns
 	mu sync.Mutex
 
-	// connCounts is a map of downstream to a count of connections
+	// connCounts is a map of downstreamID to a count of connections
 	connCounts map[string]uint32
 }
 
@@ -22,30 +22,30 @@ func NewDownstreamConns() *DownstreamConns {
 	}
 }
 
-// TryBeginConnection checks if a downstream is below a maximum
-// and if so records an additional connection for the client.
-// If the client has no history, a new count will be started.
+// TryBeginConnection checks if a DownstreamID is below a maximum
+// and if so records an additional connection for the downstream.
+// If the downstream has no history, a new count will be started.
 // The return indicates if the new connection should be allowed.
-func (t *DownstreamConns) TryBeginConnection(downstream string, max uint32) bool {
+func (t *DownstreamConns) TryBeginConnection(DownstreamID string, max uint32) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	value, ok := t.connCounts[downstream]
+	value, ok := t.connCounts[DownstreamID]
 	if !ok {
-		t.connCounts[downstream] = 1
+		t.connCounts[DownstreamID] = 1
 		return true
 	}
 	if value < max {
-		t.connCounts[downstream] = value + 1
+		t.connCounts[DownstreamID] = value + 1
 		return true
 	}
 	return false
 }
 
-// EndConnection decrements the count of connections for a given downstream.
+// EndConnection decrements the count of connections for a given DownstreamID.
 // EndConnection requires that a connection was begun previously,
 // otherwise it may access a key which does not exist.
-func (t *DownstreamConns) EndConnection(downstream string) {
+func (t *DownstreamConns) EndConnection(DownstreamID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.connCounts[downstream] -= t.connCounts[downstream]
+	t.connCounts[DownstreamID] -= t.connCounts[DownstreamID]
 }

--- a/internal/tracker/downstream.go
+++ b/internal/tracker/downstream.go
@@ -22,11 +22,11 @@ func NewDownstreamConns() *DownstreamConns {
 	}
 }
 
-// TryBeginConnection checks if a downstreamID is below a maximum
+// TryRecordConnection checks if a downstreamID's connections are below the provided max
 // and if so records an additional connection for the downstream.
 // If the downstream has no history, a new count will be started.
 // The return indicates if the new connection should be allowed.
-func (t *DownstreamConns) TryBeginConnection(downstreamID string, max uint32) bool {
+func (t *DownstreamConns) TryRecordConnection(downstreamID string, max uint32) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	value, ok := t.connCounts[downstreamID]
@@ -35,17 +35,17 @@ func (t *DownstreamConns) TryBeginConnection(downstreamID string, max uint32) bo
 		return true
 	}
 	if value < max {
-		t.connCounts[downstreamID] = value + 1
+		t.connCounts[downstreamID]++
 		return true
 	}
 	return false
 }
 
-// EndConnection decrements the count of connections for a given downstreamID.
-// EndConnection requires that a connection was begun previously,
+// ConnectionEnded decrements the count of connections for a given downstreamID.
+// ConnectionEnded requires that a connection was begun previously,
 // otherwise it may access a key which does not exist.
-func (t *DownstreamConns) EndConnection(downstreamID string) {
+func (t *DownstreamConns) ConnectionEnded(downstreamID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.connCounts[downstreamID] -= t.connCounts[downstreamID]
+	t.connCounts[downstreamID]--
 }

--- a/internal/tracker/downstream.go
+++ b/internal/tracker/downstream.go
@@ -1,0 +1,48 @@
+package tracker
+
+import (
+	"sync"
+)
+
+// DownstreamConns tracks connections per downstream based on a
+// unique string identifier.
+// DownstreamConns safe for concurrent use.
+type DownstreamConns struct {
+	mu         sync.Mutex
+	connCounts map[string]uint32
+}
+
+// NewDownstreamConns initializes and returns a DownstreamConns with
+func NewDownstreamConns() *DownstreamConns {
+	return &DownstreamConns{
+		connCounts: map[string]uint32{},
+	}
+}
+
+// TryBeginConnection checks if a downstream is below a maximum
+// and if so records an additional connection for the client.
+// If the client has no history, a new count will be started.
+// The return indicates if the new connection should be allowed.
+func (t *DownstreamConns) TryBeginConnection(downstream string, max uint32) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	value, ok := t.connCounts[downstream]
+	if !ok {
+		t.connCounts[downstream] = 1
+		return true
+	}
+	if value < max {
+		t.connCounts[downstream] = value + 1
+		return true
+	}
+	return false
+}
+
+// EndConnection decrements the count of connections for a given downstream.
+// EndConnection requires that a connection was begun previously,
+// otherwise it may access a key which does not exist.
+func (t *DownstreamConns) EndConnection(downstream string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.connCounts[downstream] -= t.connCounts[downstream]
+}

--- a/internal/tracker/downstream.go
+++ b/internal/tracker/downstream.go
@@ -42,10 +42,13 @@ func (t *DownstreamConns) TryRecordConnection(downstreamID string, max uint32) b
 }
 
 // ConnectionEnded decrements the count of connections for a given downstreamID.
-// ConnectionEnded requires that a connection was begun previously,
-// otherwise it may access a key which does not exist.
 func (t *DownstreamConns) ConnectionEnded(downstreamID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	_, ok := t.connCounts[downstreamID]
+	if !ok {
+		// id was not found
+		return
+	}
 	t.connCounts[downstreamID]--
 }

--- a/internal/tracker/downstream.go
+++ b/internal/tracker/downstream.go
@@ -8,7 +8,10 @@ import (
 // unique string identifier.
 // DownstreamConns safe for concurrent use.
 type DownstreamConns struct {
-	mu         sync.Mutex
+	// mu protects the resources of DownstreamConns
+	mu sync.Mutex
+
+	// connCounts is a map of downstream to a count of connections
 	connCounts map[string]uint32
 }
 

--- a/internal/tracker/downstream.go
+++ b/internal/tracker/downstream.go
@@ -22,30 +22,30 @@ func NewDownstreamConns() *DownstreamConns {
 	}
 }
 
-// TryBeginConnection checks if a DownstreamID is below a maximum
+// TryBeginConnection checks if a downstreamID is below a maximum
 // and if so records an additional connection for the downstream.
 // If the downstream has no history, a new count will be started.
 // The return indicates if the new connection should be allowed.
-func (t *DownstreamConns) TryBeginConnection(DownstreamID string, max uint32) bool {
+func (t *DownstreamConns) TryBeginConnection(downstreamID string, max uint32) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	value, ok := t.connCounts[DownstreamID]
+	value, ok := t.connCounts[downstreamID]
 	if !ok {
-		t.connCounts[DownstreamID] = 1
+		t.connCounts[downstreamID] = 1
 		return true
 	}
 	if value < max {
-		t.connCounts[DownstreamID] = value + 1
+		t.connCounts[downstreamID] = value + 1
 		return true
 	}
 	return false
 }
 
-// EndConnection decrements the count of connections for a given DownstreamID.
+// EndConnection decrements the count of connections for a given downstreamID.
 // EndConnection requires that a connection was begun previously,
 // otherwise it may access a key which does not exist.
-func (t *DownstreamConns) EndConnection(DownstreamID string) {
+func (t *DownstreamConns) EndConnection(downstreamID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.connCounts[DownstreamID] -= t.connCounts[DownstreamID]
+	t.connCounts[downstreamID] -= t.connCounts[downstreamID]
 }

--- a/internal/tracker/downstream_test.go
+++ b/internal/tracker/downstream_test.go
@@ -1,0 +1,109 @@
+package tracker
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestDownstreamConnsCounts(t *testing.T) {
+	downstream1 := "downstream1"
+	downstream2 := "downstream2"
+
+	tests := []struct {
+		name           string
+		op             func(*DownstreamConns)
+		expectedCounts map[string]uint32
+	}{
+		{
+			name: "record a new downstream connection if under maximum",
+			op: func(tracker *DownstreamConns) {
+				tracker.TryBeginConnection(downstream1, 10)
+			},
+			expectedCounts: map[string]uint32{
+				downstream1: 1,
+			},
+		},
+		{
+			name: "record a connection ending",
+			op: func(tracker *DownstreamConns) {
+				tracker.TryBeginConnection(downstream1, 10)
+				tracker.EndConnection(downstream1)
+			},
+			expectedCounts: map[string]uint32{
+				downstream1: 0,
+			},
+		},
+		{
+			name: "don't record connections which would extend beyond maximum",
+			op: func(tracker *DownstreamConns) {
+				tracker.TryBeginConnection(downstream1, 10)
+				tracker.TryBeginConnection(downstream1, 10)
+				tracker.TryBeginConnection(downstream2, 2)
+				tracker.TryBeginConnection(downstream2, 2)
+
+				// this connection should not be recorded because of the maximums
+				tracker.TryBeginConnection(downstream2, 2)
+				tracker.TryBeginConnection(downstream1, 10)
+
+				tracker.EndConnection(downstream1)
+				tracker.EndConnection(downstream1)
+				tracker.EndConnection(downstream1)
+				tracker.EndConnection(downstream2)
+				tracker.EndConnection(downstream2)
+
+				tracker.TryBeginConnection(downstream2, 2)
+			},
+			expectedCounts: map[string]uint32{
+				downstream1: 0,
+				downstream2: 1,
+			},
+		},
+		{
+			name: "don't record connections which would extend beyond maximum, concurrently",
+			op: func(tracker *DownstreamConns) {
+				wg := sync.WaitGroup{}
+				wg.Add(2)
+
+				// this test does not guarantee that concurrent access works,
+				// because the goroutine scheduler will typically run routines till
+				// till they cannot be run further.
+				// but it was quick to write, and does ensure that separate goroutines
+				// can end connections which they didn't begin.
+				go func() {
+					tracker.TryBeginConnection(downstream2, 2)
+					tracker.TryBeginConnection(downstream1, 10)
+					wg.Done()
+				}()
+				go func() {
+					tracker.TryBeginConnection(downstream1, 10)
+					tracker.TryBeginConnection(downstream1, 10)
+					tracker.TryBeginConnection(downstream2, 2)
+					tracker.TryBeginConnection(downstream2, 2)
+					wg.Done()
+				}()
+
+				wg.Wait()
+				tracker.EndConnection(downstream1)
+				tracker.EndConnection(downstream1)
+				tracker.EndConnection(downstream1)
+				tracker.EndConnection(downstream2)
+				tracker.EndConnection(downstream2)
+				tracker.TryBeginConnection(downstream2, 2)
+			},
+			expectedCounts: map[string]uint32{
+				downstream1: 0,
+				downstream2: 1,
+			},
+		},
+	}
+
+	for i, test := range tests {
+		tracker := NewDownstreamConns()
+		test.op(tracker)
+		actualCounts := tracker.connCounts
+		if !reflect.DeepEqual(test.expectedCounts, actualCounts) {
+			t.Errorf("test(%v) expectedCounts did not match actualCounts: \n %v != %v\n", i, test.expectedCounts, actualCounts)
+		}
+	}
+}

--- a/internal/tracker/upstream.go
+++ b/internal/tracker/upstream.go
@@ -97,8 +97,8 @@ func (t *UpstreamConns) EndConnection(id uuid.UUID) {
 	heap.Fix(t.pq, upstream.index)
 }
 
-// UpstreamUnhealthy is used to remove an upstream from the available upstreams
-func (t *UpstreamConns) UpstreamUnhealthy(id uuid.UUID) {
+// UpstreamUnavailable is used to remove an upstream from the available upstreams
+func (t *UpstreamConns) UpstreamUnavailable(id uuid.UUID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -113,8 +113,8 @@ func (t *UpstreamConns) UpstreamUnhealthy(id uuid.UUID) {
 	t.pq.remove(upstream)
 }
 
-// UpstreamHealthy is used to restore an upstream to the available upstreams
-func (t *UpstreamConns) UpstreamHealthy(id uuid.UUID) {
+// UpstreamAvailable is used to restore an upstream to the available upstreams
+func (t *UpstreamConns) UpstreamAvailable(id uuid.UUID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/internal/tracker/upstream.go
+++ b/internal/tracker/upstream.go
@@ -1,0 +1,196 @@
+package tracker
+
+import (
+	"container/heap"
+	"errors"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+var errorNoAvailableUpstream = errors.New("No Available Upstream")
+
+// UpstreamConns tracks connections for an upstreamGroup
+// on a per upstream basis. Upstreams can be marked as
+// unhealthy to prevent them from being chosen for new connections.
+// UpstreamConns handles load balancing through BeginConnection()
+type UpstreamConns struct {
+	// mu protects the resources of UpstreamConns
+	mu sync.Mutex
+
+	// upstreams holds all upstreams, healthy or unhealthy
+	upstreams map[uuid.UUID]*upstream
+
+	// pq holds healthy upstreams and provides the means to
+	// pick the upstream with the least connections.
+	pq *upstreamPQ
+}
+
+// An upstream stores a count of connections
+// as well as some overhead for use in upstreamPQ.
+type upstream struct {
+	// id is the id of the upstream
+	id uuid.UUID
+
+	// The count of connections to the upstream.
+	// Also the priority of an upstream, lowest first.
+	connCount uint32
+
+	// The index is needed by update and is maintained by the heap.Interface methods.
+	// if an upstream is pulled from the upstreamPQ (because of health)
+	// its index will be set to -1
+	index int
+}
+
+// NewUpstreamConns creates a new UpstreamConns
+// with upstreams based on provided upstreamIDs.
+// upstreams must be marked as healthy before they will be
+// added to the internal priorityQueue and available for BeginConnection()
+func NewUpstreamConns(upstreamIDs []uuid.UUID) *UpstreamConns {
+	upstreams := map[uuid.UUID]*upstream{}
+	for _, id := range upstreamIDs {
+		upstreams[id] = &upstream{
+			id:    id,
+			index: -1,
+		}
+	}
+	return &UpstreamConns{
+		upstreams: upstreams,
+		pq:        &upstreamPQ{},
+	}
+}
+
+// BeginConnection returns the UUID of the upstream with the least connections
+// and records the additional connection.
+// An error is returned if there are no available upstreams
+func (t *UpstreamConns) BeginConnection() (uuid.UUID, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	upstream := t.pq.peek()
+	if upstream == nil {
+		return uuid.UUID{}, errorNoAvailableUpstream
+	}
+
+	// do we need a check for an upstream which is not in the upstreamPQ?
+	// The assumption is that we are only incrementing upstreams which are
+	// healthy and in the upstreamPQ. unhealthy upstreams are removed from the upstreamPQ.
+	upstream.connCount += 1
+	heap.Fix(t.pq, upstream.index)
+	return upstream.id, nil
+}
+
+// EndConnection takes the UUID of the upstream which has just had a connection terminate
+// and records the ended connection.
+func (t *UpstreamConns) EndConnection(id uuid.UUID) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	upstream := t.upstreams[id]
+	upstream.connCount -= 1
+
+	if upstream.index < 0 {
+		// upstream is not in the upstreamPQ
+		return
+	}
+
+	heap.Fix(t.pq, upstream.index)
+}
+
+// UpstreamUnhealthy is used to remove an upstream from the available upstreams
+func (t *UpstreamConns) UpstreamUnhealthy(id uuid.UUID) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	upstream := t.upstreams[id]
+
+	if upstream.index < 0 {
+		// upstream is not in the upstreamPQ
+		// generally should not be possible, but safe to check
+		return
+	}
+
+	t.pq.remove(upstream)
+}
+
+// UpstreamHealthy is used to restore an upstream to the available upstreams
+func (t *UpstreamConns) UpstreamHealthy(id uuid.UUID) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	upstream := t.upstreams[id]
+
+	if upstream.index > -1 {
+		// upstream is in the upstreamPQ
+		// generally should not be possible, but safe to check
+		return
+	}
+
+	heap.Push(t.pq, upstream)
+}
+
+// A upstreamPQ implements heap.Interface and holds upstreams.
+type upstreamPQ []*upstream
+
+var _ heap.Interface = (*upstreamPQ)(nil)
+
+func (pq upstreamPQ) Len() int { return len(pq) }
+
+func (pq upstreamPQ) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].connCount < pq[j].connCount
+}
+
+func (pq upstreamPQ) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *upstreamPQ) Push(x any) {
+	n := len(*pq)
+	item := x.(*upstream)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+func (pq *upstreamPQ) Pop() any {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil  // avoid memory leak
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return item
+}
+
+// peek returns the upstream at the front of the upstreamPQ without altering or moving it
+func (pq *upstreamPQ) peek() *upstream {
+	if len(*pq) == 0 {
+		return nil
+	}
+	return (*pq)[0]
+}
+
+// remove pulls an upstream from the upstreamPQ.
+// remove assumes that up is in the upstreamPQ
+func (pq *upstreamPQ) remove(up *upstream) {
+	if len(*pq) == 1 {
+		// up is the only item in the upstreamPQ
+		pq.Pop()
+		return
+	}
+
+	i := up.index
+	j := len(*pq) - 1
+	if i == j {
+		// up is the last item in the upstreamPQ
+		pq.Pop()
+		return
+	}
+
+	// up can be swapped with the last item in the upstreamPQ (then fixed)
+	pq.Swap(i, j)
+	pq.Pop()
+	heap.Fix(pq, i)
+}

--- a/internal/tracker/upstream.go
+++ b/internal/tracker/upstream.go
@@ -80,15 +80,17 @@ func (t *UpstreamConns) NextAvailableUpstream() (uuid.UUID, error) {
 	return upstream.id, nil
 }
 
-// ConnectionEnded takes the UUID of the upstream which has just had a connection terminate
-// and records the ended connection.
-// ConnectionEnded requires that a connection was begun previously,
-// otherwise it may access a key which does not exist and panic from nil pointer dereference
+// ConnectionEnded takes the UUID of the upstream which has
+// just had a connection terminate and records the ended connection.
 func (t *UpstreamConns) ConnectionEnded(id uuid.UUID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	upstream := t.upstreams[id]
+	upstream, ok := t.upstreams[id]
+	if !ok {
+		// id was not found
+		return
+	}
 	upstream.connCount--
 
 	if upstream.index < 0 {
@@ -100,13 +102,15 @@ func (t *UpstreamConns) ConnectionEnded(id uuid.UUID) {
 }
 
 // UpstreamUnavailable is used to remove an upstream from the available upstreams
-// UpstreamUnavailable requires that the given id was provided to NewUpstreamConns(),
-// otherwise it may access a key which does not exist and panic from nil pointer dereference
 func (t *UpstreamConns) UpstreamUnavailable(id uuid.UUID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	upstream := t.upstreams[id]
+	upstream, ok := t.upstreams[id]
+	if !ok {
+		// id was not found
+		return
+	}
 
 	if upstream.index < 0 {
 		// upstream is not in the upstreamPQ
@@ -118,13 +122,15 @@ func (t *UpstreamConns) UpstreamUnavailable(id uuid.UUID) {
 }
 
 // UpstreamAvailable is used to restore an upstream to the available upstreams
-// UpstreamAvailable requires that the given id was provided to NewUpstreamConns(),
-// otherwise it may access a key which does not exist and panic from nil pointer dereference
 func (t *UpstreamConns) UpstreamAvailable(id uuid.UUID) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	upstream := t.upstreams[id]
+	upstream, ok := t.upstreams[id]
+	if !ok {
+		// id was not found
+		return
+	}
 
 	if upstream.index > -1 {
 		// upstream is in the upstreamPQ

--- a/internal/tracker/upstream_test.go
+++ b/internal/tracker/upstream_test.go
@@ -96,15 +96,20 @@ func TestUpstreamConnsCounts(t *testing.T) {
 			op: func(tracker *UpstreamConns) {
 				tracker.UpstreamHealthy(upstream1)
 				tracker.UpstreamHealthy(upstream2)
-				tracker.BeginConnection()
-				tracker.BeginConnection()
+				_, err := tracker.BeginConnection()
+				failIfNotNil(t, err)
+				_, err = tracker.BeginConnection()
+				failIfNotNil(t, err)
 
 				tracker.UpstreamUnhealthy(upstream1)
-				tracker.BeginConnection()
-				tracker.BeginConnection()
+				_, err = tracker.BeginConnection()
+				failIfNotNil(t, err)
+				_, err = tracker.BeginConnection()
+				failIfNotNil(t, err)
 
 				tracker.UpstreamHealthy(upstream1)
-				tracker.BeginConnection()
+				_, err = tracker.BeginConnection()
+				failIfNotNil(t, err)
 			},
 			expectedUpstreams: map[uuid.UUID]*upstream{
 				upstream1: {
@@ -146,5 +151,12 @@ func TestUpstreamConnsCounts(t *testing.T) {
 		if test.expectedPQ != nil && !reflect.DeepEqual(test.expectedPQ, actualPQ) {
 			t.Errorf("test(%v) expectedPQ did not match actualPQ: \n %v != %v\n", i, test.expectedPQ, actualPQ)
 		}
+	}
+}
+
+func failIfNotNil(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("unexpected error: %v\n", err)
 	}
 }

--- a/internal/tracker/upstream_test.go
+++ b/internal/tracker/upstream_test.go
@@ -1,0 +1,150 @@
+package tracker
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestUpstreamConnsCounts(t *testing.T) {
+	upstream1 := uuid.New()
+	upstream2 := uuid.New()
+
+	tests := []struct {
+		name              string
+		op                func(*UpstreamConns)
+		expectedUpstreams map[uuid.UUID]*upstream
+		// expectedPQ is only checked against if it is non-nil
+		expectedPQ *upstreamPQ
+	}{
+		{
+			name: "multiple routines requesting connections",
+			op: func(tracker *UpstreamConns) {
+				tracker.UpstreamHealthy(upstream1)
+				tracker.UpstreamHealthy(upstream2)
+
+				wg := sync.WaitGroup{}
+				wg.Add(2)
+
+				// this test does not guarantee that concurrent access works,
+				// because the goroutine scheduler will typically run routines till
+				// till they cannot be run further.
+				// but it was quick to write, and does ensure that separate goroutines
+				// can begin connections independently while balancing connections to upstreams
+
+				// spin up 2 goroutines which begin 5 connections each
+				for i := 0; i < 2; i++ {
+					go func() {
+						for j := 0; j < 5; j++ {
+							_, err := tracker.BeginConnection()
+							if err != nil {
+								t.Errorf("unexpected error: %v\n", err)
+							}
+						}
+						wg.Done()
+					}()
+				}
+				wg.Wait()
+			},
+			expectedUpstreams: map[uuid.UUID]*upstream{
+				upstream1: {
+					id:        upstream1,
+					connCount: 5,
+				},
+				upstream2: {
+					id:        upstream2,
+					connCount: 5,
+				},
+			},
+		},
+		{
+			name: "return errors when there are no available upstreams",
+			op: func(tracker *UpstreamConns) {
+				_, err := tracker.BeginConnection()
+				if !errors.Is(err, errorNoAvailableUpstream) {
+					t.Errorf("expected error %v, but got nil\n", errorNoAvailableUpstream)
+				}
+				tracker.UpstreamHealthy(upstream1)
+
+				_, err = tracker.BeginConnection()
+				if err != nil {
+					t.Errorf("unexpected error: %v\n", err)
+				}
+			},
+			expectedUpstreams: map[uuid.UUID]*upstream{
+				upstream1: {
+					id:        upstream1,
+					connCount: 1,
+				},
+				upstream2: {
+					id: upstream2,
+				},
+			},
+			expectedPQ: &upstreamPQ{
+				{
+					id:        upstream1,
+					connCount: 1,
+					index:     0,
+				},
+			},
+		},
+		{
+			name: "only allow healthy upstreams to get new connections",
+			op: func(tracker *UpstreamConns) {
+				tracker.UpstreamHealthy(upstream1)
+				tracker.UpstreamHealthy(upstream2)
+				tracker.BeginConnection()
+				tracker.BeginConnection()
+
+				tracker.UpstreamUnhealthy(upstream1)
+				tracker.BeginConnection()
+				tracker.BeginConnection()
+
+				tracker.UpstreamHealthy(upstream1)
+				tracker.BeginConnection()
+			},
+			expectedUpstreams: map[uuid.UUID]*upstream{
+				upstream1: {
+					id:        upstream1,
+					connCount: 2,
+				},
+				upstream2: {
+					id:        upstream2,
+					connCount: 3,
+				},
+			},
+			expectedPQ: &upstreamPQ{
+				{
+					id:        upstream1,
+					connCount: 2,
+					index:     0,
+				},
+				{
+					id:        upstream2,
+					connCount: 3,
+					index:     1,
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		tracker := NewUpstreamConns([]uuid.UUID{upstream1, upstream2})
+		test.op(tracker)
+		actualUpstreams := tracker.upstreams
+		for id, actualUpstream := range actualUpstreams {
+			expectedUpstream := test.expectedUpstreams[id]
+			if expectedUpstream.connCount != actualUpstream.connCount {
+				t.Errorf("test(%v) expectedCounts did not match actualCounts: \n %v != %v\n", i, expectedUpstream.connCount, actualUpstream.connCount)
+			}
+		}
+
+		actualPQ := tracker.pq
+		if test.expectedPQ != nil && !reflect.DeepEqual(test.expectedPQ, actualPQ) {
+			t.Errorf("test(%v) expectedPQ did not match actualPQ: \n %v != %v\n", i, test.expectedPQ, actualPQ)
+		}
+	}
+}


### PR DESCRIPTION
Create upstream and downstream trackers

tracker.DownstreamConns tracks connections per downstream, identified by a string.

tracker.UpstreamConns tracks connections per upstream, identified by a uuid. It also returns the uuid of an upstream id when a new connection is requested. Returned upstream will be healthy and have the lowest existing connections.